### PR TITLE
Add email and password fields to createUser API endpoint

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "lodash": "^4.17.21",
         "mongodb": "^6.6.1",
         "mongoose": "^8.3.4"
       },
@@ -368,6 +370,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1434,6 +1441,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "scripts": {
-    "db:start": "docker run --name srv-mongodb -d -p 27017:27017 mongo:8.0.0-rc15-jammy",
+    "db:setup": "docker run --name srv-mongodb -d -p 27017:27017 mongo:8.0.0-rc15-jammy",
+    "db:start": "docker start srv-mongodb",
+    "db:stop": "docker stop srv-mongodb",
     "dev": "nodemon src/index.js",
     "lint": "eslint",
     "serve": "node src/index.js",
@@ -14,8 +16,10 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "lodash": "^4.17.21",
     "mongodb": "^6.6.1",
     "mongoose": "^8.3.4"
   },

--- a/Backend/src/models/user.model.js
+++ b/Backend/src/models/user.model.js
@@ -16,6 +16,18 @@ const UserSchema = mongoose.Schema(
       type: String,
       required: false,
     },
+
+    email: {
+      type: String,
+      required: [true, "Please enter email of User"],
+      unique: true,
+    },
+
+    passwordHash: {
+      type: String,
+      required: [true, "Please enter password of User"],
+      select: false,
+    },
   },
   {
     timestamps: true,


### PR DESCRIPTION
In this PR I have done the following:

- Add `email` and `passwordHash` fields to User mongoose schema
- Add `email`, `password` and `passwordHash` properties as passable into the `createUser` endpoint (`POST /api/users/`)
- Update docker scripts in `package.json` for easier use